### PR TITLE
Declare ZoneNumber in convertLatLngToUtm

### DIFF
--- a/UTMLatLng.js
+++ b/UTMLatLng.js
@@ -15,6 +15,7 @@ function UTMLatLng(datumNameIn) {
 
 method.convertLatLngToUtm = function (latitude, longitude,precision)
 {
+    var ZoneNumber;
     if (this.status)
     {
         return 'No ecclipsoid data associated with unknown datum: ' + datumName;


### PR DESCRIPTION
We need to use this function in my company, and it fails because ZoneNumber is "not defined".
It happens as it's not even declared in the function's body.
This fix introduces the required declaration.